### PR TITLE
Fix: Prevent game conclusion to appear twice

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -71,7 +71,9 @@ function App() {
     !hasTip || 
     status === GameStatusEnum.WON || 
     status === GameStatusEnum.LOST || 
-    status === GameStatusEnum.REVEALED
+    status === GameStatusEnum.REVEALED ||
+    status === GameStatusEnum.STANDBY_LOST ||
+    status === GameStatusEnum.STANDBY_WON
   );
 
   function handleUseMyTip() {
@@ -106,13 +108,13 @@ function App() {
 
   function shouldShowRevealButton() {
     return (
-      status === GameStatusEnum.LOST || 
+      status === GameStatusEnum.STANDBY_LOST || 
       status === GameStatusEnum.REVEALED
     );
   }
 
   function shouldShowTryAgainButton() {
-    return status === GameStatusEnum.LOST;
+    return status === GameStatusEnum.STANDBY_LOST;
   }
 
   useEffect(() => {    

--- a/src/components/GameConclusion/index.tsx
+++ b/src/components/GameConclusion/index.tsx
@@ -36,7 +36,13 @@ const customStyles = {
 export const GameConclusion = ({ result }: GameConclusionProps) => {
   const [isOpen, setIsOpen] = useState(false);
 
-  const { gameState: { status }, onFindNewPokemon, onTryAgain, onRevealPokemonName } = useAppContext();
+  const { 
+    gameState: { status }, 
+    onFindNewPokemon, 
+    onTryAgain,
+    onRevealPokemonName,
+    onChangeGameStatus,
+  } = useAppContext();
 
   let content;
 
@@ -56,6 +62,16 @@ export const GameConclusion = ({ result }: GameConclusionProps) => {
 
   function handleRevealPokemonName() {
     onRevealPokemonName();
+    close();
+  }
+
+  function handleCloseGameConclusion() {
+    if (status === GameStatusEnum.WON) {
+      onChangeGameStatus(GameStatusEnum.STANDBY_WON);
+    } else {
+      onChangeGameStatus(GameStatusEnum.STANDBY_LOST);
+    }
+    
     close();
   }
 
@@ -82,7 +98,7 @@ export const GameConclusion = ({ result }: GameConclusionProps) => {
         <Button 
           icon={<Back />}
           type={ButtonTypeEnum.LINK} 
-          onClick={() => close()}
+          onClick={() => handleCloseGameConclusion()}
           ariaLabel={GO_BACK_BUTTON_LABEL}
         >
           {GO_BACK_BUTTON_LABEL}
@@ -122,7 +138,7 @@ export const GameConclusion = ({ result }: GameConclusionProps) => {
       <img style={{display: 'none'}} src="https://media2.giphy.com/media/xuXzcHMkuwvf2/giphy.gif" alt="" />
       <Modal
         isOpen={isOpen}
-        onRequestClose={close}
+        onRequestClose={handleCloseGameConclusion}
         overlayClassName="game-conclusion__overlay"
         style={customStyles}
         contentLabel="Game result"

--- a/src/contexts/AppContext/enums.ts
+++ b/src/contexts/AppContext/enums.ts
@@ -7,6 +7,8 @@ export enum GameStatusEnum {
   LOST,
   REVEALED,
   ERROR,
+  STANDBY_WON,
+  STANDBY_LOST,
 }
 
 export enum GameActionTypeEnum {


### PR DESCRIPTION
When the user cancels the "Go home" operation, the Game conclusion component no longer appears twice.